### PR TITLE
Jc keymaster 41 android 11 nvm phase 2

### DIFF
--- a/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimulator.java
+++ b/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimulator.java
@@ -1315,4 +1315,9 @@ public class KMJCardSimulator implements KMSEProvider {
   public KMPreSharedKey getPresharedKey() {
     return (KMPreSharedKey) preSharedKey;
   }
+
+  @Override
+  public void releaseAllOperations() {
+    //Do nothing.
+  }
 }

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
@@ -453,7 +453,7 @@ public class KMFunctionalTest {
   private static final short MAJOR_TYPE_MASK = 0xE0;
   private static final byte CBOR_ARRAY_MAJOR_TYPE = (byte) 0x80;
   private static final byte CBOR_UINT_MAJOR_TYPE = 0x00;
-  private static final short CANARY_BIT_FLAG = (short) 0x4000;
+  private static final short SE_POWER_RESET_FLAG = (short) 0x4000;
   private static final boolean RESET = true;
   private static final boolean NO_RESET = false;
 
@@ -1969,7 +1969,7 @@ public class KMFunctionalTest {
     short ret = decoder.decode(KMInteger.exp(), respBuf, (short) 0, (short) respBuf.length);
     if (triggerReset) {
       short error = KMInteger.cast(ret).getSignificantShort();
-      Assert.assertEquals(error, CANARY_BIT_FLAG);
+      Assert.assertEquals(error, SE_POWER_RESET_FLAG);
     }
     return ret;
   }
@@ -2837,7 +2837,7 @@ public class KMFunctionalTest {
       //Call begin1 end----------------
 
       //Call update operation----------------
-      // Call update operation and check if the canary bit is set or not.
+      // Call update operation and check if the secure element power reset flag is set or not.
       short dataPtr = KMByteBlob.instance(input, (short) 0, (short) input.length);
       opHandle = KMInteger.instance(opHandleBuf, (short) 0, (short) opHandleBuf.length);
       // update with trigger reset.
@@ -2850,7 +2850,7 @@ public class KMFunctionalTest {
       //Call update end----------------
 
       //Call update1 operation----------------
-      // Call update1 operation and check if the canary bit is set or not.
+      // Call update1 operation and check if the secure element power reset flag is set or not.
       dataPtr = KMByteBlob.instance(input, (short) 0, (short) input.length);
       opHandle1 = KMInteger.instance(opHandleBuf1, (short) 0, (short) opHandleBuf1.length);
       // update with trigger reset.
@@ -2863,7 +2863,7 @@ public class KMFunctionalTest {
       //Call update end----------------
 
       //Call finish operation----------------
-      // Call finish operation and check if the canary bit is set or not.
+      // Call finish operation and check if the secure element power reset flag is set or not.
       dataPtr = KMByteBlob.instance((short) 0);
       opHandle = KMInteger.uint_64(opHandleBuf, (short) 0);
       short expectedErr = KMError.OK;
@@ -2874,7 +2874,7 @@ public class KMFunctionalTest {
       //Call finish end----------------
 
       //Call finish1 operation----------------
-      // Call finish1 operation and check if the canary bit is set or not.
+      // Call finish1 operation and check if the secure element power reset flag is set or not.
       dataPtr = KMByteBlob.instance((short) 0);
       opHandle1 = KMInteger.instance(opHandleBuf1, (short) 0, (short) opHandleBuf1.length);
       expectedErr = KMError.OK;
@@ -2885,7 +2885,7 @@ public class KMFunctionalTest {
       //Call finish end----------------
 
       //Call abort operation----------------
-      // Call abort operation and check if the canary bit is set or not.
+      // Call abort operation and check if the secure element power reset flag is set or not.
       opHandle = KMInteger.uint_64(opHandleBuf, (short) 0);
       ret = abort(opHandle, resetEvents[i][6]);
       if (resetEvents[i][1] || resetEvents[i][2] | resetEvents[i][3] | resetEvents[i][4] | resetEvents[i][5] | resetEvents[i][6]) {
@@ -3379,14 +3379,14 @@ public class KMFunctionalTest {
       Assert.assertEquals(error, KMError.OK);
       if (triggerReset) {
         error = KMInteger.cast(KMArray.cast(ret).get((short) 0)).getSignificantShort();
-        Assert.assertEquals(error, CANARY_BIT_FLAG);
+        Assert.assertEquals(error, SE_POWER_RESET_FLAG);
       }
       return ret;
     } else {//Major type UINT.
       ret = decoder.decode(KMInteger.exp(), respBuf, (short) 0, len);
       if (triggerReset) {
         short error = KMInteger.cast(ret).getSignificantShort();
-        Assert.assertEquals(error, CANARY_BIT_FLAG);
+        Assert.assertEquals(error, SE_POWER_RESET_FLAG);
       }
       return KMInteger.cast(ret).getShort();
       /*if (len == 3) {
@@ -3474,15 +3474,15 @@ public class KMFunctionalTest {
     if (expectedErr == KMError.OK) {
       error = KMInteger.cast(KMArray.cast(ret).get((short) 0)).getShort();
       if (triggerReset) {
-        short canaryBit = KMInteger.cast(KMArray.cast(ret).get((short) 0)).getSignificantShort();
-        Assert.assertEquals(canaryBit, CANARY_BIT_FLAG);
+        short powerResetStatus = KMInteger.cast(KMArray.cast(ret).get((short) 0)).getSignificantShort();
+        Assert.assertEquals(powerResetStatus, SE_POWER_RESET_FLAG);
       }
     } else {
       error = KMInteger.cast(ret).getShort();
       error = translateExtendedErrorCodes(error);
       if (triggerReset) {
-        short canaryBit = KMInteger.cast(ret).getSignificantShort();
-        Assert.assertEquals(canaryBit, CANARY_BIT_FLAG);
+        short powerResetStatus = KMInteger.cast(ret).getSignificantShort();
+        Assert.assertEquals(powerResetStatus, SE_POWER_RESET_FLAG);
       }
     }
     Assert.assertEquals(error, expectedErr);
@@ -3528,13 +3528,13 @@ public class KMFunctionalTest {
       Assert.assertEquals(error, KMError.OK);
       if (triggerReset) {
         error = KMInteger.cast(KMArray.cast(ret).get((short) 0)).getSignificantShort();
-        Assert.assertEquals(error, CANARY_BIT_FLAG);
+        Assert.assertEquals(error, SE_POWER_RESET_FLAG);
       }
     } else {
       ret = decoder.decode(KMInteger.exp(), respBuf, (short)0, len);
       if (triggerReset) {
-        short canaryBit = KMInteger.cast(ret).getSignificantShort();
-        Assert.assertEquals(canaryBit, CANARY_BIT_FLAG);
+        short powerResetStatus = KMInteger.cast(ret).getSignificantShort();
+        Assert.assertEquals(powerResetStatus, SE_POWER_RESET_FLAG);
       }
     }
     return ret;

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
@@ -678,6 +678,13 @@ public class KMFunctionalTest {
     simulator.deleteApplet(appletAID);
   }
 
+  private void resetAndSelect() {
+    simulator.reset();
+    AID appletAID = AIDUtil.create("A000000062");
+    // Select applet
+    simulator.selectApplet(appletAID);
+  }
+
 
   private CommandAPDU encodeApdu(byte ins, short cmd) {
     byte[] buf = new byte[2500];
@@ -1955,9 +1962,7 @@ public class KMFunctionalTest {
     CommandAPDU apdu = encodeApdu((byte) INS_ABORT_OPERATION_CMD, arrPtr);
     // print(commandAPDU.getBytes());
     if (triggerReset) {
-      simulator.reset();
-      AID appletAID1 = AIDUtil.create("A000000062");
-      simulator.selectApplet(appletAID1);
+      resetAndSelect();
     }
     ResponseAPDU response = simulator.transmitCommand(apdu);
     byte[] respBuf = response.getBytes();
@@ -2776,7 +2781,7 @@ public class KMFunctionalTest {
     cleanUp();
   }
 
-  public void testBeginResetUpdate() {
+  public void testCardRest() {
     byte[] input = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
     // Test different combinations of reset events happening in the ordered flow of
     // begin - begin1 - update - update1 - finish - finish1 - abort
@@ -2891,7 +2896,7 @@ public class KMFunctionalTest {
   @Test
   public void testCardResetFunctionality() {
     init();
-    testBeginResetUpdate();
+    testCardRest();
     cleanUp();
   }
 
@@ -3351,9 +3356,7 @@ public class KMFunctionalTest {
     KMArray.cast(arrPtr).add((short) 3, hwToken);
     CommandAPDU apdu = encodeApdu((byte) INS_BEGIN_OPERATION_CMD, arrPtr);
     if (triggerReset) {
-      simulator.reset();
-      AID appletAID = AIDUtil.create("A000000062");
-      simulator.selectApplet(appletAID);
+      resetAndSelect();
     }
     //print(apdu.getBytes(),(short)0,(short)apdu.getBytes().length);
     ResponseAPDU response = simulator.transmitCommand(apdu);
@@ -3447,9 +3450,7 @@ public class KMFunctionalTest {
     CommandAPDU apdu = encodeApdu((byte) INS_FINISH_OPERATION_CMD, arrPtr);
     // print(commandAPDU.getBytes());
     if (triggerReset) {
-      simulator.reset();
-      AID appletAID = AIDUtil.create("A000000062");
-      simulator.selectApplet(appletAID);
+      resetAndSelect();
     }
     ResponseAPDU response = simulator.transmitCommand(apdu);
     byte[] respBuf = response.getBytes();
@@ -3504,9 +3505,7 @@ public class KMFunctionalTest {
     KMArray.cast(arrPtr).add((short) 4, verToken);
     CommandAPDU apdu = encodeApdu((byte) INS_UPDATE_OPERATION_CMD, arrPtr);
     if (triggerReset) {
-      simulator.reset();
-      AID appletAID = AIDUtil.create("A000000062");
-      simulator.selectApplet(appletAID);
+      resetAndSelect();
     }
     // print(commandAPDU.getBytes());
     ResponseAPDU response = simulator.transmitCommand(apdu);

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
@@ -2888,7 +2888,7 @@ public class KMFunctionalTest {
       // Call abort operation and check if the canary bit is set or not.
       opHandle = KMInteger.uint_64(opHandleBuf, (short) 0);
       ret = abort(opHandle, resetEvents[i][6]);
-      if (resetEvents[i][2] | resetEvents[i][3] | resetEvents[i][4] | resetEvents[i][5] | resetEvents[i][6]) {
+      if (resetEvents[i][1] || resetEvents[i][2] | resetEvents[i][3] | resetEvents[i][4] | resetEvents[i][5] | resetEvents[i][6]) {
         short err = KMInteger.cast(ret).getShort();
         Assert.assertEquals(KMError.INVALID_OPERATION_HANDLE, err);
       }

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
@@ -1967,6 +1967,10 @@ public class KMFunctionalTest {
     ResponseAPDU response = simulator.transmitCommand(apdu);
     byte[] respBuf = response.getBytes();
     short ret = decoder.decode(KMInteger.exp(), respBuf, (short) 0, (short) respBuf.length);
+    if (triggerReset) {
+      short error = KMInteger.cast(ret).getSignificantShort();
+      Assert.assertEquals(error, CANARY_BIT_FLAG);
+    }
     return ret;
   }
 

--- a/Applet/src/com/android/javacard/keymaster/KMEncoder.java
+++ b/Applet/src/com/android/javacard/keymaster/KMEncoder.java
@@ -56,7 +56,7 @@ public class KMEncoder {
     bufferRef[0] = null;
     scratchBuf[START_OFFSET] = (short) 0;
     scratchBuf[LEN_OFFSET] = (short) 0;
-    scratchBuf[STACK_PTR_OFFSET] = (short) 0;    
+    scratchBuf[STACK_PTR_OFFSET] = (short) 0;
   }
 
   private void push(short objPtr) {

--- a/Applet/src/com/android/javacard/keymaster/KMEncoder.java
+++ b/Applet/src/com/android/javacard/keymaster/KMEncoder.java
@@ -315,7 +315,7 @@ public class KMEncoder {
     case 3: case 4: //Uint32
       return (short) 5;
     case 5: case 6: case 7: case 8: //Uint64
-      return (short) 5;
+      return (short) 9;
     default:
       ISOException.throwIt(ISO7816.SW_DATA_INVALID);
     }

--- a/Applet/src/com/android/javacard/keymaster/KMEncoder.java
+++ b/Applet/src/com/android/javacard/keymaster/KMEncoder.java
@@ -108,7 +108,7 @@ public class KMEncoder {
     scratchBuf[LEN_OFFSET] = (short) (certStart + 1);
     //Array header - 2 elements i.e. 1 byte
     scratchBuf[START_OFFSET]--;
-    // errInt32Ptr - CanaryBit + ErrorCode - 4 bytes
+    // errInt32Ptr - PowerResetStatus + ErrorCode - 4 bytes
     // Integer header - 1 byte
     scratchBuf[START_OFFSET] -= getEncodedIntegerLength(errInt32Ptr);
     //Array header - 2 elements i.e. 1 byte
@@ -123,7 +123,7 @@ public class KMEncoder {
     }
     bufferStart = scratchBuf[START_OFFSET];
     writeMajorTypeWithLength(ARRAY_TYPE, (short) 2); // Array of 2 elements
-    encodeInteger(errInt32Ptr); //CanaryBit + ErrorCode
+    encodeInteger(errInt32Ptr); //PowerResetStatus + ErrorCode
     writeMajorTypeWithLength(ARRAY_TYPE, (short) 1); // Array of 1 element
     writeMajorTypeWithLength(BYTES_TYPE, certLength); // Cert Byte Blob of length
     return bufferStart;

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -202,6 +202,8 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
       keymasterState = KMKeymasterApplet.INIT_STATE;
       seProvider.createMasterKey((short) (KMRepository.MASTER_KEY_SIZE * 8));
     } else {
+      // This flag is explicitly set after upgrade, to make sure that
+      // Keymaster HAL releases its operation state table.
       cardResetStatus = CANARY_BIT_FLAG;
     }
     KMType.initialize();

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -308,6 +308,8 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   // Call this fucntion before processing the apdu.
   private void updateCardResetFlag() {
     if (repository.isResetEventOccurred()) {
+      // Release all the operation instances.
+      seProvider.releaseAllOperations();
       JCSystem.beginTransaction();
       cardResetStatus = CANARY_BIT_FLAG;
       JCSystem.commitTransaction();
@@ -322,7 +324,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   @Override
   public void process(APDU apdu) {
     try {
-      // Get and udpate the card reset status before processing apdu.
+      // Get and update the card reset status before processing apdu.
       updateCardResetFlag();
       repository.onProcess();
       // Verify whether applet is in correct state.

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -653,7 +653,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     tmpVariables[0] = seProvider.getCertificateChainLength();
     short int32Ptr = getErrorStatusWithPowerResetStatusSet(KMError.OK);
     //Total Extra length
-    // Add arrayHeader and (CanaryBitSet + KMError.OK)
+    // Add arrayHeader and (PowerResetStatus + KMError.OK)
     tmpVariables[2] = (short) (1 + encoder.getEncodedIntegerLength(int32Ptr));
     tmpVariables[0] += tmpVariables[2];
     tmpVariables[1] = KMByteBlob.instance(tmpVariables[0]);

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -41,7 +41,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   private static final short KM_HAL_VERSION = (short) 0x4000;
   private static final short MAX_AUTH_DATA_SIZE = (short) 512;
   private static final short DERIVE_KEY_INPUT_SIZE = (short) 256;
-  private static final short POWER_RESET_STATUS_FLAG = (short) 0x4000;
+  private static final short POWER_RESET_MASK_FLAG = (short) 0x4000;
 
   // "Keymaster HMAC Verification" - used for HMAC key verification.
   public static final byte[] sharingCheck = {
@@ -651,7 +651,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   private void processGetCertChainCmd(APDU apdu) {
     // Make the response
     tmpVariables[0] = seProvider.getCertificateChainLength();
-    short int32Ptr = getErrorStatusWithPowerResetStatusSet(KMError.OK);
+    short int32Ptr = buildErrorStatus(KMError.OK);
     //Total Extra length
     // Add arrayHeader and (PowerResetStatus + KMError.OK)
     tmpVariables[2] = (short) (1 + encoder.getEncodedIntegerLength(int32Ptr));
@@ -847,7 +847,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
   private void processGetProvisionStatusCmd(APDU apdu) {
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, KMInteger.uint_16(provisionStatus));
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -922,7 +922,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     checkVersionAndPatchLevel(scratchPad);
     // make response.
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_CHARACTERISTICS]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -939,7 +939,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     KMHmacSharingParameters.cast(tmpVariables[2]).setSeed(KMByteBlob.instance((short) 0));
     // prepare the response
     tmpVariables[3] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[3]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[3]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[3]).add((short) 1, tmpVariables[2]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1105,7 +1105,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     tmpVariables[1] = KMByteBlob.instance(scratchPad, tmpVariables[6], tmpVariables[5]);
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, tmpVariables[1]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1183,7 +1183,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     }
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1461,7 +1461,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     cert.build();
     bufferProp[BUF_START_OFFSET] =
         encoder.encodeCert((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], cert.getCertStart(), cert.getCertLength(),
-            getErrorStatusWithPowerResetStatusSet(KMError.OK));
+            buildErrorStatus(KMError.OK));
     bufferProp[BUF_LEN_OFFSET] = (short) (cert.getCertLength() + (cert.getCertStart() - bufferProp[BUF_START_OFFSET]));
     sendOutgoing(apdu);
   }
@@ -1626,7 +1626,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     if (data[OUTPUT_DATA] == KMType.INVALID_VALUE) {
       data[OUTPUT_DATA] = KMByteBlob.instance((short) 0);
     }
-    KMArray.cast(tmpVariables[2]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[2]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[2]).add((short) 1, tmpVariables[1]);
     KMArray.cast(tmpVariables[2]).add((short) 2, data[OUTPUT_DATA]);
 
@@ -2108,7 +2108,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     if (data[OUTPUT_DATA] == KMType.INVALID_VALUE) {
       data[OUTPUT_DATA] = KMByteBlob.instance((short) 0);
     }
-    KMArray.cast(tmpVariables[2]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[2]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[2]).add((short) 1, KMInteger.uint_16(tmpVariables[3]));
     KMArray.cast(tmpVariables[2]).add((short) 2, tmpVariables[1]);
     KMArray.cast(tmpVariables[2]).add((short) 3, data[OUTPUT_DATA]);
@@ -2214,7 +2214,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     }
     tmpVariables[1] = KMKeyParameters.instance(tmpVariables[2]);
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, tmpVariables[1]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[OP_HANDLE]);
 
@@ -2824,7 +2824,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[KEY_CHARACTERISTICS]);
 
@@ -3326,7 +3326,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithPowerResetStatusSet(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, buildErrorStatus(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[KEY_CHARACTERISTICS]);
 
@@ -3834,11 +3834,15 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     return tmpVariables[3];
   }
 
-  private static short getErrorStatusWithPowerResetStatusSet(short err) {
+  // This function masks the error code with POWER_RESET_MASK_FLAG
+  // in case if card reset event occurred. The clients of the Applet
+  // has to extract the power reset status from the error code and
+  // process accordingly.
+  private static short buildErrorStatus(short err) {
     short int32Ptr = KMInteger.instance((short) 4);
     short powerResetStatus = 0;
     if (repository.isPowerResetEventOccurred()) {
-      powerResetStatus = POWER_RESET_STATUS_FLAG;
+      powerResetStatus = POWER_RESET_MASK_FLAG;
     }
 
     Util.setShort(KMInteger.cast(int32Ptr).getBuffer(),
@@ -3849,13 +3853,14 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
         (short) (KMInteger.cast(int32Ptr).getStartOff() + 2),
         err);
 
+    // reset power reset status flag to its default value.
     repository.restorePowerResetStatus();
     return int32Ptr;
   }
 
   private static void sendError(APDU apdu, short err) {
     bufferProp[BUF_START_OFFSET] = repository.alloc((short) 5);
-    short int32Ptr = getErrorStatusWithPowerResetStatusSet(err);
+    short int32Ptr = buildErrorStatus(err);
     bufferProp[BUF_LEN_OFFSET] = encoder.encodeError(int32Ptr, (byte[]) bufferRef[0],
         bufferProp[BUF_START_OFFSET], (short) 5);
     sendOutgoing(apdu);

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -41,6 +41,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   private static final short KM_HAL_VERSION = (short) 0x4000;
   private static final short MAX_AUTH_DATA_SIZE = (short) 512;
   private static final short DERIVE_KEY_INPUT_SIZE = (short) 256;
+  private static final short CANARY_BIT_FLAG = (short) 0x40;
 
   // "Keymaster HMAC Verification" - used for HMAC key verification.
   public static final byte[] sharingCheck = {
@@ -214,6 +215,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     bufferProp[BUF_START_OFFSET] = 0;
     bufferProp[BUF_LEN_OFFSET] = 0;
   }
+
   /**
    * Selects this applet.
    *
@@ -644,17 +646,20 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   private void processGetCertChainCmd(APDU apdu) {
     // Make the response
     tmpVariables[0] = seProvider.getCertificateChainLength();
-    // Add arrayHeader and KMError.OK
-    tmpVariables[0] += 2;
+    short int32Ptr = getErrorStatusWithCanaryBitSet(KMError.OK);
+    //Total Extra length
+    // Add arrayHeader and (CanaryBitSet + KMError.OK)
+    tmpVariables[2] = (short) (2 + KMInteger.cast(int32Ptr).length());
+    tmpVariables[0] += tmpVariables[2];
     tmpVariables[1] = KMByteBlob.instance(tmpVariables[0]);
     bufferRef[0] = KMByteBlob.cast(tmpVariables[1]).getBuffer();
     bufferProp[BUF_START_OFFSET] = KMByteBlob.cast(tmpVariables[1]).getStartOff();
     bufferProp[BUF_LEN_OFFSET] = KMByteBlob.cast(tmpVariables[1]).length();
     // read the cert chain from non-volatile memory. Cert chain is already in
     // CBOR format.
-    seProvider.readCertificateChain((byte[]) bufferRef[0], (short) (bufferProp[BUF_START_OFFSET] + 2));
+    seProvider.readCertificateChain((byte[]) bufferRef[0], (short) (bufferProp[BUF_START_OFFSET] + tmpVariables[2]));
     // Encode cert chain.
-    encoder.encodeCertChain((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], bufferProp[BUF_LEN_OFFSET]);
+    encoder.encodeCertChain((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], bufferProp[BUF_LEN_OFFSET], int32Ptr);
     sendOutgoing(apdu);
   }
 
@@ -837,7 +842,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
   private void processGetProvisionStatusCmd(APDU apdu) {
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, KMInteger.uint_16(provisionStatus));
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -912,7 +917,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     checkVersionAndPatchLevel(scratchPad);
     // make response.
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_CHARACTERISTICS]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -929,7 +934,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     KMHmacSharingParameters.cast(tmpVariables[2]).setSeed(KMByteBlob.instance((short) 0));
     // prepare the response
     tmpVariables[3] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[3]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[3]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[3]).add((short) 1, tmpVariables[2]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1095,7 +1100,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     tmpVariables[1] = KMByteBlob.instance(scratchPad, tmpVariables[6], tmpVariables[5]);
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, tmpVariables[1]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1113,8 +1118,8 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
       // OS version in key characteristics must be less the OS version stored in Javacard or the
       // stored version must be zero. Then only upgrade is allowed else it is invalid argument.
       if ((tag == KMType.OS_VERSION
-              && KMInteger.compare(tmpVariables[0], systemParam) == 1
-              && KMInteger.compare(systemParam, tmpVariables[1]) == 0)) {
+          && KMInteger.compare(tmpVariables[0], systemParam) == 1
+          && KMInteger.compare(systemParam, tmpVariables[1]) == 0)) {
         // Key needs upgrade.
         return true;
       } else if ((KMInteger.compare(tmpVariables[0], systemParam) == -1)) {
@@ -1173,7 +1178,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     }
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 2);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
 
     bufferProp[BUF_START_OFFSET] = repository.allocAvailableMemory();
@@ -1450,7 +1455,8 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     cert.buffer((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], bufferProp[BUF_LEN_OFFSET]);
     cert.build();
     bufferProp[BUF_START_OFFSET] =
-        encoder.encodeCert((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], cert.getCertStart(), cert.getCertLength());
+        encoder.encodeCert((byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], cert.getCertStart(), cert.getCertLength(),
+            getErrorStatusWithCanaryBitSet(KMError.OK));
     bufferProp[BUF_LEN_OFFSET] = (short) (cert.getCertLength() + (cert.getCertStart() - bufferProp[BUF_START_OFFSET]));
     sendOutgoing(apdu);
   }
@@ -1615,7 +1621,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     if (data[OUTPUT_DATA] == KMType.INVALID_VALUE) {
       data[OUTPUT_DATA] = KMByteBlob.instance((short) 0);
     }
-    KMArray.cast(tmpVariables[2]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[2]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[2]).add((short) 1, tmpVariables[1]);
     KMArray.cast(tmpVariables[2]).add((short) 2, data[OUTPUT_DATA]);
 
@@ -1773,18 +1779,18 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
           if (op.getPurpose() == KMType.SIGN) {
             // len of signature will be 256 bytes
             short len = op.getOperation().sign(
-                    KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
-                    KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
-                    KMByteBlob.cast(data[INPUT_DATA]).length(), scratchPad,
-                    (short) 0);
+                KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
+                KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
+                KMByteBlob.cast(data[INPUT_DATA]).length(), scratchPad,
+                (short) 0);
             // Maximum output size of signature is 256 bytes.
             data[OUTPUT_DATA] = KMByteBlob.instance((short) 256);
             Util.arrayCopyNonAtomic(
-                    scratchPad,
-                    (short) 0,
-                    KMByteBlob.cast(data[OUTPUT_DATA]).getBuffer(),
-                    (short) (KMByteBlob.cast(data[OUTPUT_DATA]).getStartOff() + 256 - len),
-                    len);
+                scratchPad,
+                (short) 0,
+                KMByteBlob.cast(data[OUTPUT_DATA]).getBuffer(),
+                (short) (KMByteBlob.cast(data[OUTPUT_DATA]).getStartOff() + 256 - len),
+                len);
           } else {
             KMException.throwIt(KMError.UNSUPPORTED_PURPOSE);
           }
@@ -2097,7 +2103,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     if (data[OUTPUT_DATA] == KMType.INVALID_VALUE) {
       data[OUTPUT_DATA] = KMByteBlob.instance((short) 0);
     }
-    KMArray.cast(tmpVariables[2]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[2]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[2]).add((short) 1, KMInteger.uint_16(tmpVariables[3]));
     KMArray.cast(tmpVariables[2]).add((short) 2, tmpVariables[1]);
     KMArray.cast(tmpVariables[2]).add((short) 3, data[OUTPUT_DATA]);
@@ -2203,7 +2209,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     }
     tmpVariables[1] = KMKeyParameters.instance(tmpVariables[2]);
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, tmpVariables[1]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[OP_HANDLE]);
 
@@ -2813,7 +2819,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[KEY_CHARACTERISTICS]);
 
@@ -3315,7 +3321,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
 
     // prepare the response
     tmpVariables[0] = KMArray.instance((short) 3);
-    KMArray.cast(tmpVariables[0]).add((short) 0, KMInteger.uint_16(KMError.OK));
+    KMArray.cast(tmpVariables[0]).add((short) 0, getErrorStatusWithCanaryBitSet(KMError.OK));
     KMArray.cast(tmpVariables[0]).add((short) 1, data[KEY_BLOB]);
     KMArray.cast(tmpVariables[0]).add((short) 2, data[KEY_CHARACTERISTICS]);
 
@@ -3623,20 +3629,20 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
       tmpVariables[0] = KMByteBlob.cast(data[KEY_BLOB]).getStartOff();
       tmpVariables[1] = KMArray.instance((short) 5);
       KMArray.cast(tmpVariables[1]).add(KMKeymasterApplet.KEY_BLOB_SECRET,
-              KMByteBlob.exp());
+          KMByteBlob.exp());
       KMArray.cast(tmpVariables[1]).add(KMKeymasterApplet.KEY_BLOB_AUTH_TAG,
-              KMByteBlob.exp());
+          KMByteBlob.exp());
       KMArray.cast(tmpVariables[1]).add(KMKeymasterApplet.KEY_BLOB_NONCE,
-              KMByteBlob.exp());
+          KMByteBlob.exp());
       tmpVariables[2] = KMKeyCharacteristics.exp();
       KMArray.cast(tmpVariables[1]).add(KMKeymasterApplet.KEY_BLOB_KEYCHAR,
-              tmpVariables[2]);
+          tmpVariables[2]);
       KMArray.cast(tmpVariables[1]).add(KMKeymasterApplet.KEY_BLOB_PUB_KEY,
-              KMByteBlob.exp());
+          KMByteBlob.exp());
       data[KEY_BLOB] = decoder.decodeArray(tmpVariables[1],
-              KMByteBlob.cast(data[KEY_BLOB]).getBuffer(),
-              KMByteBlob.cast(data[KEY_BLOB]).getStartOff(),
-              KMByteBlob.cast(data[KEY_BLOB]).length());
+          KMByteBlob.cast(data[KEY_BLOB]).getBuffer(),
+          KMByteBlob.cast(data[KEY_BLOB]).getStartOff(),
+          KMByteBlob.cast(data[KEY_BLOB]).length());
       tmpVariables[0] = KMArray.cast(data[KEY_BLOB]).length();
       if (tmpVariables[0] < 4) {
         KMException.throwIt(KMError.INVALID_KEY_BLOB);
@@ -3647,18 +3653,18 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
       data[NONCE] = KMArray.cast(data[KEY_BLOB]).get(KEY_BLOB_NONCE);
       data[SECRET] = KMArray.cast(data[KEY_BLOB]).get(KEY_BLOB_SECRET);
       data[KEY_CHARACTERISTICS] = KMArray.cast(data[KEY_BLOB]).get(
-              KEY_BLOB_KEYCHAR);
+          KEY_BLOB_KEYCHAR);
       data[PUB_KEY] = KMType.INVALID_VALUE;
       if (tmpVariables[0] == 5) {
         data[PUB_KEY] = KMArray.cast(data[KEY_BLOB]).get(KEY_BLOB_PUB_KEY);
       }
       data[HW_PARAMETERS] = KMKeyCharacteristics
-              .cast(data[KEY_CHARACTERISTICS]).getHardwareEnforced();
+          .cast(data[KEY_CHARACTERISTICS]).getHardwareEnforced();
       data[SW_PARAMETERS] = KMKeyCharacteristics
-              .cast(data[KEY_CHARACTERISTICS]).getSoftwareEnforced();
+          .cast(data[KEY_CHARACTERISTICS]).getSoftwareEnforced();
 
       data[HIDDEN_PARAMETERS] = KMKeyParameters.makeHidden(data[APP_ID],
-              data[APP_DATA], data[ROT], scratchPad);
+          data[APP_DATA], data[ROT], scratchPad);
       // make auth data
       makeAuthData(scratchPad);
       // Decrypt Secret and verify auth tag
@@ -3823,9 +3829,26 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     return tmpVariables[3];
   }
 
+  private static short getErrorStatusWithCanaryBitSet(short err) {
+    short int32Ptr = KMInteger.instance((short) 4);
+    if (repository.isResetEventOccurred()) {
+      repository.resetSeStatusFlag();
+      //Set the canary bit
+      Util.setShort(KMInteger.cast(int32Ptr).getBuffer(),
+          KMInteger.cast(int32Ptr).getStartOff(),
+          CANARY_BIT_FLAG);
+    }
+    Util.setShort(KMInteger.cast(int32Ptr).getBuffer(),
+        (short) (KMInteger.cast(int32Ptr).getStartOff() + 2),
+        err);
+    return int32Ptr;
+  }
+
   private static void sendError(APDU apdu, short err) {
     bufferProp[BUF_START_OFFSET] = repository.alloc((short) 2);
-    bufferProp[BUF_LEN_OFFSET] = encoder.encodeError(err, (byte[]) bufferRef[0], bufferProp[BUF_START_OFFSET], (short) 5);
+    short int32Ptr = getErrorStatusWithCanaryBitSet(err);
+    bufferProp[BUF_LEN_OFFSET] = encoder.encode(int32Ptr, (byte[]) bufferRef[0],
+        bufferProp[BUF_START_OFFSET]);
     sendOutgoing(apdu);
   }
 

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -665,7 +665,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
     short int32Ptr = getErrorStatusWithCanaryBitSet(KMError.OK);
     //Total Extra length
     // Add arrayHeader and (CanaryBitSet + KMError.OK)
-    tmpVariables[2] = (short) (2 + KMInteger.cast(int32Ptr).length());
+    tmpVariables[2] = (short) (1 + encoder.getEncodedIntegerLength(int32Ptr));
     tmpVariables[0] += tmpVariables[2];
     tmpVariables[1] = KMByteBlob.instance(tmpVariables[0]);
     bufferRef[0] = KMByteBlob.cast(tmpVariables[1]).getBuffer();
@@ -3865,10 +3865,10 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   }
 
   private static void sendError(APDU apdu, short err) {
-    bufferProp[BUF_START_OFFSET] = repository.alloc((short) 2);
+    bufferProp[BUF_START_OFFSET] = repository.alloc((short) 5);
     short int32Ptr = getErrorStatusWithCanaryBitSet(err);
-    bufferProp[BUF_LEN_OFFSET] = encoder.encode(int32Ptr, (byte[]) bufferRef[0],
-        bufferProp[BUF_START_OFFSET]);
+    bufferProp[BUF_LEN_OFFSET] = encoder.encodeError(int32Ptr, (byte[]) bufferRef[0],
+        bufferProp[BUF_START_OFFSET], (short) 5);
     sendOutgoing(apdu);
   }
 

--- a/Applet/src/com/android/javacard/keymaster/KMRepository.java
+++ b/Applet/src/com/android/javacard/keymaster/KMRepository.java
@@ -91,7 +91,9 @@ public class KMRepository implements KMUpgradable {
   private byte[] dataTable;
   private short dataIndex;
   private short[] reclaimIndex;
-  // This variable is used to check if power reset event occurred.
+  // This variable is used to monitor the power reset status as the Applet does not get
+  // any power reset event. Initially the value of this variable is set to POWER_RESET_STATUS_FLAG.
+  // If the power reset happens then this value becomes 0.
   private byte[] powerResetStatus;
 
   // Operation table.
@@ -135,7 +137,8 @@ public class KMRepository implements KMUpgradable {
     repository = this;
   }
 
-  // This function should only be called before processing any of the APUs.
+  // This function checks if card reset event occurred and this function
+  // should only be called before processing any of the APUs.
   // Transient memory is cleared in two cases:
   // 1. Card reset event
   // 2. Applet upgrade.
@@ -146,6 +149,10 @@ public class KMRepository implements KMUpgradable {
     return true;
   }
 
+  /**
+   * This function sets the power reset status flag to its
+   * default value.
+   */
   public void restorePowerResetStatus() {
     powerResetStatus[0] = POWER_RESET_STATUS_FLAG;
   }

--- a/Applet/src/com/android/javacard/keymaster/KMSEProvider.java
+++ b/Applet/src/com/android/javacard/keymaster/KMSEProvider.java
@@ -559,4 +559,10 @@ public interface KMSEProvider extends KMUpgradable {
    */
   KMPreSharedKey getPresharedKey();
 
+  /**
+   * Releases all the instance back to pool.
+   * Generally this is used when card is reset.
+   */
+  void releaseAllOperations();
+
 }

--- a/HAL/keymaster/4.1/JavacardKeymaster4Device.cpp
+++ b/HAL/keymaster/4.1/JavacardKeymaster4Device.cpp
@@ -233,9 +233,12 @@ static void deleteOprHandleEntry(uint64_t halGeneratedOperationHandle) {
 
 /* Clears all the strongbox operation handle entries from operation table */
 static void clearStrongboxOprHandleEntries(const std::unique_ptr<OperationContext>& oprCtx) {
+    LOG(WARNING) << "secure element reset occurred. All the below mentioned operation handles becomes invalid"
+        << " and the owners of these operations has to restart the operation again.";
     auto it = operationTable.begin();
     while (it != operationTable.end()) {
         if (it->second.second == SB_KM_OPR) { //Strongbox operation
+            LOG(WARNING) << "operation handle: "(int32_t) it->first << " is invalid";
             oprCtx->clearOperationData(it->second.first);
             it = operationTable.erase(it);
         } else {
@@ -1038,6 +1041,9 @@ Return<void> JavacardKeymaster4Device::update(uint64_t halGeneratedOprHandle, co
     uint64_t operationHandle;
     UpdateOperationResponse response;
     if (ErrorCode::OK != (errorCode = getOrigOperationHandle(halGeneratedOprHandle, operationHandle))) {
+        LOG(ERROR) << " Operation handle is invalid. This could happen if invalid operation handle is passed or if"
+            << " secure element reset occurred. In case if secure element reset occured owner"
+            << "has to restart this operation again.";
         _hidl_cb(errorCode, inputConsumed, outParams, output);
         return Void();
     }
@@ -1139,6 +1145,9 @@ Return<void> JavacardKeymaster4Device::finish(uint64_t halGeneratedOprHandle, co
     FinishOperationResponse response;
 
     if (ErrorCode::OK != (errorCode = getOrigOperationHandle(halGeneratedOprHandle, operationHandle))) {
+        LOG(ERROR) << " Operation handle is invalid. This could happen if invalid operation handle is passed or if"
+            << " secure element reset occurred. In case if secure element reset occured owner"
+            << "has to restart this operation again.";
         _hidl_cb(errorCode, outParams, output);
         return Void();
     }
@@ -1258,6 +1267,8 @@ Return<ErrorCode> JavacardKeymaster4Device::abort(uint64_t halGeneratedOprHandle
     ErrorCode errorCode = ErrorCode::UNKNOWN_ERROR;
     uint64_t operationHandle;
     if (ErrorCode::OK != (errorCode = getOrigOperationHandle(halGeneratedOprHandle, operationHandle))) {
+        LOG(ERROR) << " Operation handle is invalid. This could happen if invalid operation handle is passed or if"
+            << " secure element reset occurred.";
         return errorCode;
     }
     AbortOperationRequest request;

--- a/HAL/keymaster/4.1/JavacardKeymaster4Device.cpp
+++ b/HAL/keymaster/4.1/JavacardKeymaster4Device.cpp
@@ -231,12 +231,12 @@ static void deleteOprHandleEntry(uint64_t halGeneratedOperationHandle) {
 
 /* Clears all the strongbox operation handle entries from operation table */
 static void clearStrongboxOprHandleEntries(const std::unique_ptr<OperationContext>& oprCtx) {
-    LOG(WARNING) << "secure element reset occurred. All the below mentioned operation handles becomes invalid"
-        << " and the owners of these operations has to restart the operation again.";
+    LOG(WARNING) << "secure element reset occurred. All the below operation handles for private key operations"
+        << " becomes invalid and the owners of these operations has to restart the operation again.";
     auto it = operationTable.begin();
     while (it != operationTable.end()) {
         if (it->second.second == SB_KM_OPR) { //Strongbox operation
-            LOG(WARNING) << "operation handle: "(int32_t) it->first << " is invalid";
+            LOG(WARNING) << "operation handle: " << it->first << " is invalid";
             oprCtx->clearOperationData(it->second.first);
             it = operationTable.erase(it);
         } else {
@@ -288,7 +288,7 @@ static std::tuple<std::unique_ptr<Item>, T> decodeData(CborConverter& cb, const 
 
     // SE sends errocode as unsigned value so convert the unsigned value
     // into a signed value of same magnitude and copy back to errorCode.
-    errorCode = static_cast<T>(get2sCompliment(tempErrorCode));
+    errorCode = static_cast<T>(get2sCompliment(tempErrCode));
 
     if (T::OK != errorCode)
         errorCode = translateExtendedErrorsToHalErrors<T>(errorCode);

--- a/HAL/keymaster/include/CborConverter.h
+++ b/HAL/keymaster/include/CborConverter.h
@@ -65,7 +65,7 @@ class CborConverter
                 } else if (MajorType::UINT == getType(item)) {
                     uint64_t err;
                     if(getUint64(item, err)) {
-                        errorCode = static_cast<T>(get2sCompliment(static_cast<uint32_t>(err)));
+                        errorCode = static_cast<T>(err);
                     }
                     item = nullptr; /*Already read the errorCode. So no need of sending item to client */
                 }
@@ -162,18 +162,13 @@ class CborConverter
                 if (!getUint64<uint64_t>(item, pos, errorVal)) {
                     return ret;
                 }
-                errorCode = static_cast<T>(get2sCompliment(static_cast<uint32_t>(errorVal)));
+                errorCode = static_cast<T>(errorVal);
 
                 ret = true;
                 return ret;
             }
 
     private:
-        /**
-         * Returns the negative value of the same number.
-         */
-        inline int32_t get2sCompliment(uint32_t value) { return static_cast<int32_t>(~value+1); }
-
         /**
          * Get the type of the Item pointer.
          */

--- a/ProvisioningTool/Provision.cpp
+++ b/ProvisioningTool/Provision.cpp
@@ -131,13 +131,13 @@ static inline int32_t get2sCompliment(uint32_t value) {
  * This function separates the original error code from the
  * power reset flag and returns the original error code.
  */
-static uint32_t extractOriginalErrorCode(uint32_t errorCode) {
+static uint32_t extractErrorCode(uint32_t errorCode) {
     //Check if secure element is reset
     bool isSeResetOccurred = (0 != (errorCode & SE_POWER_RESET_STATUS_FLAG));
 
     if (isSeResetOccurred) {
         LOG(ERROR) << "Secure element reset happened";
-        return (errorCode & ~SE_POWER_RESET_STATUS_FLAG);
+        errorCode &= ~SE_POWER_RESET_STATUS_FLAG;
     }
     return errorCode;
 }
@@ -147,9 +147,8 @@ static std::tuple<std::unique_ptr<Item>, T> decodeData(CborConverter& cb, const 
     std::unique_ptr<Item> item(nullptr);
     T errorCode = T::OK;
     std::tie(item, errorCode) = cb.decodeData<T>(response, true);
-    int32_t temp = static_cast<int32_t>(errorCode);
 
-    uint32_t tempErrCode = extractOriginalErrorCode(static_cast<uint32_t>(errorCode));
+    uint32_t tempErrCode = extractErrorCode(static_cast<uint32_t>(errorCode));
 
     // SE sends errocode as unsigned value so convert the unsigned value
     // into a signed value of same magnitude and copy back to errorCode.

--- a/ProvisioningTool/Provision.cpp
+++ b/ProvisioningTool/Provision.cpp
@@ -35,6 +35,9 @@
 #define APDU_P1  0x40
 #define APDU_P2  0x00
 #define APDU_RESP_STATUS_OK 0x9000
+#define CANARY_BIT_FLAG ( 1 << 30)
+#define UNSET_CANARY_BIT(a) (a &= ~CANARY_BIT_FLAG)
+#define TWOS_COMPLIMENT(a) (a = ~a + 1)
 
 namespace keymaster {
 namespace V4_1 {
@@ -52,6 +55,23 @@ enum class Instruction {
     INS_GET_PROVISION_STATUS_CMD = INS_BEGIN_KM_CMD+8,
 };
 
+//Extended error codes
+enum ExtendedErrors {
+    SW_CONDITIONS_NOT_SATISFIED = -10001,
+    UNSUPPORTED_CLA = -10002,
+    INVALID_P1P2 = -10003,
+    UNSUPPORTED_INSTRUCTION = -10004,
+    CMD_NOT_ALLOWED = -10005,
+    SW_WRONG_LENGTH = -10006,
+    INVALID_DATA = -10007,
+    CRYPTO_ILLEGAL_USE = -10008,
+    CRYPTO_ILLEGAL_VALUE = -10009,
+    CRYPTO_INVALID_INIT = -10010,
+    CRYPTO_NO_SUCH_ALGORITHM = -10011,
+    CRYPTO_UNINITIALIZED_KEY = -10012,
+    GENERIC_UNKNOWN_ERROR = -10013
+};
+
 enum ProvisionStatus {
     NOT_PROVISIONED = 0x00,
     PROVISION_STATUS_ATTESTATION_KEY = 0x01,
@@ -67,6 +87,65 @@ enum ProvisionStatus {
 static ErrorCode constructApduMessage(Instruction& ins, std::vector<uint8_t>& inputData, std::vector<uint8_t>& apduOut);
 static ErrorCode sendProvisionData(std::unique_ptr<se_transport::TransportFactory>& transport, Instruction ins, std::vector<uint8_t>& inData, std::vector<uint8_t>& response);
 static uint16_t getStatus(std::vector<uint8_t>& inputData);
+template<typename T = ErrorCode>
+static std::tuple<std::unique_ptr<Item>, T> decodeData(CborConverter& cb, const std::vector<uint8_t>& response);
+template<typename T = ErrorCode>
+static T translateExtendedErrorsToHalErrors(T& errorCode);
+
+template<typename T>
+static T translateExtendedErrorsToHalErrors(T& errorCode) {
+    T err;
+    switch(static_cast<int32_t>(errorCode)) {
+        case SW_CONDITIONS_NOT_SATISFIED:
+        case UNSUPPORTED_CLA:
+        case INVALID_P1P2:
+        case INVALID_DATA:
+        case CRYPTO_ILLEGAL_USE:
+        case CRYPTO_ILLEGAL_VALUE:
+        case CRYPTO_INVALID_INIT:
+        case CRYPTO_UNINITIALIZED_KEY:
+        case GENERIC_UNKNOWN_ERROR:
+            err = T::UNKNOWN_ERROR;
+            break;
+        case CRYPTO_NO_SUCH_ALGORITHM:
+            err = T::UNSUPPORTED_ALGORITHM;
+            break;
+        case UNSUPPORTED_INSTRUCTION:
+        case CMD_NOT_ALLOWED:
+        case SW_WRONG_LENGTH:
+            err = T::UNIMPLEMENTED;
+            break;
+        default:
+            err = static_cast<T>(errorCode);
+            break;
+    }
+    return err;
+}
+
+template<typename T>
+static std::tuple<std::unique_ptr<Item>, T> decodeData(CborConverter& cb, const std::vector<uint8_t>& response) {
+    std::unique_ptr<Item> item(nullptr);
+    T errorCode = T::OK;
+    std::tie(item, errorCode) = cb.decodeData<T>(response, true);
+    int32_t temp = static_cast<int32_t>(errorCode);
+
+    bool canaryBitSet = (0 != (temp & CANARY_BIT_FLAG));
+
+    if (canaryBitSet) {
+        LOG(INFO) << "Secureelement reset happened";
+        UNSET_CANARY_BIT(temp);
+    }
+    // SE sends errocode as unsigned value so convert the unsigned value
+    // into a signed value of same magnitude.
+    TWOS_COMPLIMENT(temp);
+
+    //Write back temp to errorCode
+    errorCode = static_cast<T>(temp);
+
+    if (T::OK != errorCode)
+        errorCode = translateExtendedErrorsToHalErrors<T>(errorCode);
+    return {std::move(item), errorCode};
+}
 
 static inline X509* parseDerCertificate(std::vector<uint8_t>& certData) {
     X509 *x509 = NULL;
@@ -173,8 +252,7 @@ static ErrorCode sendProvisionData(std::unique_ptr<se_transport::TransportFactor
 
     if((response.size() > 2)) {
         //Skip last 2 bytes in cborData, it contains status.
-        std::tie(item, ret) = cborConverter.decodeData(std::vector<uint8_t>(response.begin(), response.end()-2),
-                true);
+        std::tie(item, ret) = decodeData(cborConverter, std::vector<uint8_t>(response.begin(), response.end()-2));
     } else {
         ret = ErrorCode::UNKNOWN_ERROR;
     }
@@ -366,8 +444,7 @@ ErrorCode Provision::getProvisionStatus(uint64_t& status) {
         return errorCode;
     }
     //Check if SE is provisioned.
-    std::tie(item, errorCode) = cborConverter.decodeData(std::vector<uint8_t>(response.begin(), response.end()-2),
-            true);
+    std::tie(item, errorCode) = decodeData(cborConverter, std::vector<uint8_t>(response.begin(), response.end()-2));
     if(item != NULL) {
 
         if(!cborConverter.getUint64(item, 1, status)) {


### PR DESCRIPTION
1. Release all the pool instances back to pool memory when card reset happens. Added new function in KMSEProvider interface (releaseAllOperations()). 
2. Always pass the card reset status back to HAL in the response along with error code (CANARY_BIT_FLAG + KMError)
3. Use reclaimIndex (KMRepository.java) as the basis to confirm the card reset event
4. Handle the errorCode with CANARY_BIT_FLAG in the HAL side.
5. when card upgrade happens explicitly set CANARY_BIT_FLAG to make sure that HAL release its operation table.
6.  Moved operationTable from EEPROM to RAM  (Modified files: KMRepository.java and KMOperationState.java)
7. Moved KMOperationImpl from EEPROM to RM (Inside AndroidSEProvider).
8.  At the begining of the process() function update card reset status.
9. Updated the Unit test to test different combinations of card reset functinality.