### PR TITLE
Judgement fall into failure case

### DIFF
--- a/HAL/OmapiTransport.cpp
+++ b/HAL/OmapiTransport.cpp
@@ -194,8 +194,8 @@ bool OmapiTransport::internalTransmitApdu(
     }
 
     if ((selectResponse.size() < 2) 
-        || ((selectResponse[selectResponse.size() -1] & 0xFF) == 0x00) 
-        || ((selectResponse[selectResponse.size() -2] & 0xFF) == 0x90))
+        || ((selectResponse[selectResponse.size() -1] & 0xFF) != 0x00) 
+        || ((selectResponse[selectResponse.size() -2] & 0xFF) != 0x90))
     {
         LOG(ERROR) << "Failed to select the Applet.";
         return false;


### PR DESCRIPTION
If AID selection successfully get xx .. .. 90 00 response. Current judgement would fall into the error case.
Need update to make it working as expected.