### PR TITLE
Reserved 4, 5 and 6 INS values for vendor usage.

### DIFF
--- a/Applet/AndroidSEProvider/src/com/android/javacard/keymaster/KMAndroidSEApplet.java
+++ b/Applet/AndroidSEProvider/src/com/android/javacard/keymaster/KMAndroidSEApplet.java
@@ -45,10 +45,7 @@ public class KMAndroidSEApplet extends KMKeymasterApplet implements OnUpgradeLis
   // Provider specific Commands
   private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
   private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
-  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 4;
-  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5; // Unused
-  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 6;
+  // Commands 4, 5 and 6 are reserved for vendor usage.
   private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
   //0x08 was reserved for INS_INIT_STRONGBOX_CMD
   //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
@@ -59,7 +56,11 @@ public class KMAndroidSEApplet extends KMKeymasterApplet implements OnUpgradeLis
       INS_KEYMINT_PROVIDER_APDU_START + 13;
   private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
       INS_KEYMINT_PROVIDER_APDU_START + 14;
- private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;  // Unused
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
+  private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 18;
 
   private static final byte INS_KEYMINT_PROVIDER_APDU_END = 0x1F;
   public static final byte BOOT_KEY_MAX_SIZE = 32;

--- a/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimApplet.java
+++ b/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimApplet.java
@@ -31,24 +31,25 @@ public class KMJCardSimApplet extends KMKeymasterApplet {
   private static final byte ILLEGAL_STATE = KM_BEGIN_STATE + 1;
   private static final short POWER_RESET_MASK_FLAG = (short) 0x4000;
 
-//Provider specific Commands
- private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
- private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
- private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-     INS_KEYMINT_PROVIDER_APDU_START + 4;
- private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5; // Unused
- private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 6;
- private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
- //0x08 was reserved for INS_INIT_STRONGBOX_CMD
- //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
- private static final byte INS_SE_FACTORY_PROVISIONING_LOCK_CMD = INS_KEYMINT_PROVIDER_APDU_START + 10;
- private static final byte INS_PROVISION_OEM_ROOT_PUBLIC_KEY_CMD = INS_KEYMINT_PROVIDER_APDU_START + 11;
- private static final byte INS_OEM_UNLOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 12;
- private static final byte INS_PROVISION_RKP_DEVICE_UNIQUE_KEYPAIR_CMD =
+  // Provider specific Commands
+  private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
+  private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
+  // Commands 4, 5 and 6 are reserved for vendor usage.
+  private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
+  // 0x08 was reserved for INS_INIT_STRONGBOX_CMD
+  // 0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
+  private static final byte INS_SE_FACTORY_PROVISIONING_LOCK_CMD = INS_KEYMINT_PROVIDER_APDU_START + 10;
+  private static final byte INS_PROVISION_OEM_ROOT_PUBLIC_KEY_CMD = INS_KEYMINT_PROVIDER_APDU_START + 11;
+  private static final byte INS_OEM_UNLOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 12;
+  private static final byte INS_PROVISION_RKP_DEVICE_UNIQUE_KEYPAIR_CMD =
      INS_KEYMINT_PROVIDER_APDU_START + 13;
- private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
+  private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
      INS_KEYMINT_PROVIDER_APDU_START + 14;
- private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;  // Unused
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
+  private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 18;
 
   private static final byte INS_KEYMINT_PROVIDER_APDU_END = 0x1F;
   public static final byte BOOT_KEY_MAX_SIZE = 32;

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMProvision.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMProvision.java
@@ -41,10 +41,6 @@ public class KMProvision {
   // Provision Instructions
   private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
   private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
-  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 4;
-  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5; // Unused
-  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 6;
   private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
   //0x08 was reserved for INS_INIT_STRONGBOX_CMD
   //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
@@ -55,7 +51,11 @@ public class KMProvision {
       INS_KEYMINT_PROVIDER_APDU_START + 13;
   private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
       INS_KEYMINT_PROVIDER_APDU_START + 14;
-  private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
+  private static final byte INS_PROVISION_SECURE_BOOT_MODE_CMD = INS_KEYMINT_PROVIDER_APDU_START + 18;
   // Top 32 commands are reserved for provisioning.
   private static final byte INS_END_KM_PROVISION_CMD = 0x20;
 

--- a/ProvisioningTool/include/constants.h
+++ b/ProvisioningTool/include/constants.h
@@ -103,16 +103,16 @@ constexpr char kSecureBootMode[] = "secure_boot_mode";
 
 // Instruction constatnts
 constexpr int kAttestationIdsCmd = INS_BEGIN_KM_CMD + 3;
-constexpr int kPresharedSecretCmd = INS_BEGIN_KM_CMD + 4;
-constexpr int kBootParamsCmd = INS_BEGIN_KM_CMD + 5;
-constexpr int kOemLockProvisionCmd = INS_BEGIN_KM_CMD + 6;
+constexpr int kPresharedSecretCmd = INS_BEGIN_KM_CMD + 15;
+constexpr int kBootParamsCmd = INS_BEGIN_KM_CMD + 16;
+constexpr int kOemLockProvisionCmd = INS_BEGIN_KM_CMD + 17;
 constexpr int kGetProvisionStatusCmd = INS_BEGIN_KM_CMD + 7;
 constexpr int kSeFactoryLockCmd = INS_BEGIN_KM_CMD + 10;
 constexpr int kOemRootPublicKeyCmd = INS_BEGIN_KM_CMD + 11;
 constexpr int kOemUnLockProvisionCmd = INS_BEGIN_KM_CMD + 12;
 constexpr int kDeviceUniqueKeyCmd = INS_BEGIN_KM_CMD + 13;
 constexpr int kAdditionalCertChainCmd = INS_BEGIN_KM_CMD + 14;
-constexpr int kSecureBootModeCmd = INS_BEGIN_KM_CMD + 15;
+constexpr int kSecureBootModeCmd = INS_BEGIN_KM_CMD + 18;
 
 
 


### PR DESCRIPTION
And allocated new values 15, 16 and 17 to the existing commands.
INS_PROVISION_PRESHARED_SECRET_CMD 15
INS_SET_BOOT_PARAMS_CMD 16
INS_OEM_LOCK_PROVISIONING_CMD 17