### PR TITLE
Reserved 4, 5 and 6 INS values for vendor usage.

### DIFF
--- a/Applet/AndroidSEProvider/src/com/android/javacard/keymaster/KMAndroidSEApplet.java
+++ b/Applet/AndroidSEProvider/src/com/android/javacard/keymaster/KMAndroidSEApplet.java
@@ -44,10 +44,7 @@ public class KMAndroidSEApplet extends KMKeymasterApplet implements OnUpgradeLis
   // Provider specific Commands
   private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
   private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
-  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 4;
-  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5;
-  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 6;
+  // 4,5 and 6 are reserved for vendor usage.
   private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
   //0x08 was reserved for INS_INIT_STRONGBOX_CMD
   //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
@@ -58,6 +55,10 @@ public class KMAndroidSEApplet extends KMKeymasterApplet implements OnUpgradeLis
       INS_KEYMINT_PROVIDER_APDU_START + 13;
   private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
       INS_KEYMINT_PROVIDER_APDU_START + 14;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
   
   private static final byte INS_KEYMINT_PROVIDER_APDU_END = 0x1F;
   public static final byte BOOT_KEY_MAX_SIZE = 32;

--- a/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimApplet.java
+++ b/Applet/JCardSimProvider/src/com/android/javacard/keymaster/KMJCardSimApplet.java
@@ -33,10 +33,7 @@ public class KMJCardSimApplet extends KMKeymasterApplet {
   // Provider specific Commands
   private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
   private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
-  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 4;
-  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5;
-  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 6;
+  // 4, 5 and 6 are reserved for vendor usage.
   private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
   //0x08 was reserved for INS_INIT_STRONGBOX_CMD
   //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
@@ -47,6 +44,10 @@ public class KMJCardSimApplet extends KMKeymasterApplet {
       INS_KEYMINT_PROVIDER_APDU_START + 13;
   private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
       INS_KEYMINT_PROVIDER_APDU_START + 14;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
   
   private static final byte INS_KEYMINT_PROVIDER_APDU_END = 0x1F;
   public static final byte BOOT_KEY_MAX_SIZE = 32;

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMFunctionalTest.java
@@ -127,8 +127,7 @@ public class KMFunctionalTest {
   public static final byte INS_UPDATE_CHALLENGE_CMD = KEYMINT_CMD_APDU_START + 32; //0x40
   public static final byte INS_FINISH_SEND_DATA_CMD = KEYMINT_CMD_APDU_START + 33; //0x41
   public static final byte INS_GET_RESPONSE_CMD = KEYMINT_CMD_APDU_START + 34; //0x42
-
-  private static final byte KEYMINT_CMD_APDU_END = KEYMINT_CMD_APDU_START + 48; //0x50
+  private static final byte KEYMINT_CMD_APDU_END = KEYMINT_CMD_APDU_START + 35; //0x43
   private static final byte INS_END_KM_CMD = 0x7F;
   private static final byte[] rsa_key_pkcs8 = {
       (byte) 0x30, (byte) 0x82, (byte) 0x04, (byte) 0xbc, (byte) 0x02, (byte) 0x01, (byte) 0x00,

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMProvision.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMProvision.java
@@ -38,24 +38,23 @@ import org.junit.Assert;
 public class KMProvision {
 
   // Provision Instructions
+  // Provider specific Commands
   private static final byte INS_KEYMINT_PROVIDER_APDU_START = 0x00;
-  private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 1;
-  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 2;
-  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
-  private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 4;
-  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 5;
+  private static final byte INS_PROVISION_ATTEST_IDS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 3;
+  private static final byte INS_GET_PROVISION_STATUS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 7;
+  //0x08 was reserved for INS_INIT_STRONGBOX_CMD
+  //0x09 was reserved for INS_SET_BOOT_ENDED_CMD earlier. it is unused now.
+  private static final byte INS_SE_FACTORY_PROVISIONING_LOCK_CMD = INS_KEYMINT_PROVIDER_APDU_START + 10;
+  private static final byte INS_PROVISION_OEM_ROOT_PUBLIC_KEY_CMD = INS_KEYMINT_PROVIDER_APDU_START + 11;
+  private static final byte INS_OEM_UNLOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 12;
   private static final byte INS_PROVISION_RKP_DEVICE_UNIQUE_KEYPAIR_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 6;
+      INS_KEYMINT_PROVIDER_APDU_START + 13;
   private static final byte INS_PROVISION_RKP_ADDITIONAL_CERT_CHAIN_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 7;
-  private static final byte INS_SET_BOOT_ENDED_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 8; //unused
-  private static final byte INS_SE_FACTORY_PROVISIONING_LOCK_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 9;
-  private static final byte INS_PROVISION_OEM_ROOT_PUBLIC_KEY_CMD =
-      INS_KEYMINT_PROVIDER_APDU_START + 10;
-  private static final byte INS_OEM_UNLOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 11;
+      INS_KEYMINT_PROVIDER_APDU_START + 14;
+  private static final byte INS_PROVISION_PRESHARED_SECRET_CMD =
+      INS_KEYMINT_PROVIDER_APDU_START + 15;
+  private static final byte INS_SET_BOOT_PARAMS_CMD = INS_KEYMINT_PROVIDER_APDU_START + 16;
+  private static final byte INS_OEM_LOCK_PROVISIONING_CMD = INS_KEYMINT_PROVIDER_APDU_START + 17;
   // Top 32 commands are reserved for provisioning.
   private static final byte INS_END_KM_PROVISION_CMD = 0x20;
 

--- a/Applet/JCardSimProvider/test/com/android/javacard/test/KMRKPFunctionalTest.java
+++ b/Applet/JCardSimProvider/test/com/android/javacard/test/KMRKPFunctionalTest.java
@@ -260,7 +260,7 @@ public class KMRKPFunctionalTest {
     init();
     short[] noOfKeys = {0, 5, 10};
     for (int i = 0; i < noOfKeys.length; i++) {
-      testGenerateCsr(noOfKeys[i] /*no_keys*/, (short) 2 /*eek_chain_len*/, true /*testMode*/);
+      testGenerateCsr(noOfKeys[i] /*no_keys*/, (short) 2 /*eek_chain_len*/, false /*testMode*/);
       KMRepository.instance().clean();
     }
     cleanUp();

--- a/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -184,8 +184,8 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
   private static final byte INS_END_KM_CMD = 0x7F;
   // Instruction values from 0xCD to 0xFF are completely reserved for Vendors to use and
   // will never be used by the base line code in future.
-  private static final byte INS_KM_VENDOR_START_CMD = 0xCD;
-  private static final byte INS_KM_VENDOR_END_CMD = 0xFF;
+  private static final byte INS_KM_VENDOR_START_CMD = (byte) 0xCD;
+  private static final byte INS_KM_VENDOR_END_CMD = (byte) 0xFF;
 
   // Data Dictionary items
   public static final byte DATA_ARRAY_SIZE = 40;

--- a/ProvisioningTool/include/constants.h
+++ b/ProvisioningTool/include/constants.h
@@ -102,9 +102,9 @@ constexpr char kUnLockProvision[] = "unlock_provision";
 
 // Instruction constatnts
 constexpr int kAttestationIdsCmd = INS_BEGIN_KM_CMD + 3;
-constexpr int kPresharedSecretCmd = INS_BEGIN_KM_CMD + 4;
-constexpr int kBootParamsCmd = INS_BEGIN_KM_CMD + 5;
-constexpr int kOemLockProvisionCmd = INS_BEGIN_KM_CMD + 6;
+constexpr int kPresharedSecretCmd = INS_BEGIN_KM_CMD + 15;
+constexpr int kBootParamsCmd = INS_BEGIN_KM_CMD + 16;
+constexpr int kOemLockProvisionCmd = INS_BEGIN_KM_CMD + 17;
 constexpr int kGetProvisionStatusCmd = INS_BEGIN_KM_CMD + 7;
 constexpr int kSeFactoryLockCmd = INS_BEGIN_KM_CMD + 10;
 constexpr int kOemRootPublicKeyCmd = INS_BEGIN_KM_CMD + 11;


### PR DESCRIPTION
And allocated new values 15, 16 and 17 to the existing commands.
INS_PROVISION_PRESHARED_SECRET_CMD 15
INS_SET_BOOT_PARAMS_CMD 16
INS_OEM_LOCK_PROVISIONING_CMD 17